### PR TITLE
Fix grid space bug on safari (#26)

### DIFF
--- a/bemo/mixins/_grid.sass
+++ b/bemo/mixins/_grid.sass
@@ -4,7 +4,9 @@
   margin-left: -$grid-gutter
   padding-left: 0
   padding-right: 0
-  letter-spacing: -1000em
+  font-size: 0
+  &* 
+    font-size: initial
 
 @mixin grid-item
   display: inline-block


### PR DESCRIPTION
Patch for white-space appearing between inline-blocks on safari.

Issue is described here: https://github.com/cantierecreativo/bemo/issues/26